### PR TITLE
Create EchoOutput handler

### DIFF
--- a/src/Symfony/Component/Console/Output/EchoOutput.php
+++ b/src/Symfony/Component/Console/Output/EchoOutput.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Jonas Bechtel <msg@jbechtel.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Output;
+
+/**
+ * EchoOutput writes the output using the common php echo command.
+ */
+class EchoOutput extends Output {
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected function doWrite($message, $newline) {
+        if ($newline) {
+                echo $message . PHP_EOL;
+        } else {
+                echo $message;
+        }
+    }
+}
+


### PR DESCRIPTION
This simplifies migration from/to Symfony Console Components and enables integration with CGI helpers which just support echo.
(Inspired by BufferedOutput)

| Q             | A
| ------------- | ---
| Branch?       | 4.4 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs #12518

Create EchoOutput handler

This simplifies migration from/to Symfony Console Components and enables integration with CGI helpers which just support echo.
(Inspired by BufferedOutput)

I did _not_ update CHANGELOG.md as I didn't find this file.
I did _not_ add a test for this.
Doc PR is against master, not against 4.4. Sorry.
